### PR TITLE
Use variable-time verification

### DIFF
--- a/src/range_proof.rs
+++ b/src/range_proof.rs
@@ -8,7 +8,7 @@
 use curve25519_dalek::{
     ristretto::{CompressedRistretto, RistrettoPoint},
     scalar::Scalar,
-    traits::{Identity, MultiscalarMul},
+    traits::{Identity, MultiscalarMul, VartimeMultiscalarMul},
 };
 use merlin::Transcript;
 use rand::thread_rng;
@@ -550,7 +550,7 @@ impl RangeProof {
             points.push(hi_base[i]);
         }
 
-        if RistrettoPoint::multiscalar_mul(scalars, points) != RistrettoPoint::identity() {
+        if RistrettoPoint::vartime_multiscalar_mul(scalars, points) != RistrettoPoint::identity() {
             return Err(ProofError::VerificationFailed(
                 "Range proof batch not valid".to_string(),
             ));


### PR DESCRIPTION
The multiscalar multiplication currently uses constant-time verification. Since the verifier holds no secrets entering this operation, we can switch to a variable-time operation. This reduces verification time significantly.